### PR TITLE
Temporary- changed label to not be visible

### DIFF
--- a/src/edu/usfca/xj/appkit/gview/shape/SLabel.java
+++ b/src/edu/usfca/xj/appkit/gview/shape/SLabel.java
@@ -42,7 +42,7 @@ public class SLabel implements XJXMLSerializable {
     protected Vector2D position = null;
     protected String title = null;
     protected Color color = Color.black;
-    protected boolean visible = true;
+    protected boolean visible = false;
 
     public SLabel() {
 


### PR DESCRIPTION
Removed transition labels from graphic. Transition labels are still
present in bottom panel. Only temporary fix, will clean up as necessary
later.